### PR TITLE
Fix yat executable

### DIFF
--- a/yat_app/yat.qrc
+++ b/yat_app/yat.qrc
@@ -1,5 +1,7 @@
 <RCC>
     <qresource>
         <file>main.qml</file>
+        <file>TabBar.qml</file>
+        <file>TabView.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
yat fails to start due to missing files.
Add all QML files to the resources.