### PR TITLE
Set default font according to the OS

### DIFF
--- a/backend/screen.cpp
+++ b/backend/screen.cpp
@@ -101,7 +101,11 @@ QFont Screen::font() const
     static QFont font;
     font.setPixelSize(14);
     font.setStyleHint(QFont::Monospace);
+#if defined(Q_OS_MAC)
     font.setFamily("Menlo");
+#else
+    font.setFamily("monospace");
+#endif
 
     QFontInfo fi(font);
     qDebug() << fi.family() << fi.exactMatch();


### PR DESCRIPTION
Set "Menlo" on macOS since it is available only there and use "monospace"
on other systems.